### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Overlay.jl is a **Julia library package** (not a service/app). There are no databases,
+servers, or ports. End-to-end usage = build deps, run the test suite, and (for the GUI)
+calibrate an image. Julia (>= 1.10) is installed via `juliaup`; the `julia` binary lives at
+`~/.juliaup/bin/julia` and is on `PATH` in interactive shells.
+
+### Build / test / run
+
+- Install/refresh deps: `julia --project=. -e 'using Pkg; Pkg.instantiate()'`
+  (this is the startup update script; first run precompiles GLMakie/Makie and is slow, ~5 min).
+- Run tests: `julia --project=. -e 'using Pkg; Pkg.test()'` (runs `test/runtests.jl`;
+  mirrors CI in `.github/workflows/CI.yml`). The test suite is headless — it does not open a window.
+- Lint: there is **no configured lint step** (no `.JuliaFormatter.toml`, none in CI). The
+  test suite is the canonical check.
+
+### Non-obvious gotchas
+
+- **Headless GUI/rendering needs a virtual display.** The interactive `calibrate_image` GUI and
+  any GLMakie figure-saving (`save("fig.png", fig)`) require an OpenGL/X display. On this VM use
+  `xvfb-run -a julia --project=. <script>`. Mesa software GLX is present, so Xvfb is sufficient;
+  no GPU is required. The automated tests do NOT need this.
+- **`Axis`/`Figure` name clash:** both `GLMakie` and `Images` export `Axis` (and some other
+  names). When `using Overlay` (which re-uses both), qualify Makie entry points in your own
+  scripts, e.g. `GLMakie.Figure(...)`, `GLMakie.Axis(...)`, `GLMakie.scatter!`,
+  `GLMakie.axislegend`. `plot_calibrated_image!` itself is exported by Overlay and needs no prefix.
+- The core coordinate/calibration API (`calibration_from_clicks`, `pixel_to_data*`,
+  `data_to_pixel*`, `x_data_coords`/`y_data_coords`, `save_calibration`/`load_calibration`) is
+  pure and runs without any display.
+- `Manifest.toml` is gitignored; deps are resolved fresh by `Pkg.instantiate()`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for **Overlay.jl** (a Julia library for over-plotting data on literature figures) so future Cloud Agents can build, test, and run it.

- Installs Julia 1.10 via `juliaup` (baked into the VM snapshot).
- Update script refreshes deps on startup: `julia --project=. -e 'using Pkg; Pkg.instantiate()'`.
- Adds `AGENTS.md` with `## Cursor Cloud specific instructions` covering build/test commands and non-obvious gotchas (headless GLMakie needs `xvfb-run`; `Axis`/`Figure` name clash between `GLMakie` and `Images`).

No application code changed.

## Verification

- ✅ `julia --project=. -e 'using Pkg; Pkg.instantiate()'` — deps precompiled (GLMakie/Makie/Images).
- ✅ `julia --project=. -e 'using Pkg; Pkg.test()'` — all 46 tests pass.
- ✅ End-to-end hello-world: load a plot image → `calibration_from_clicks` → coordinate round-trip → `save/load_calibration` → `plot_calibrated_image!` + overlay → render PNG (under `xvfb-run`).

Hello-world result (literature curve calibrated + my red data overlaid in data coordinates, with calibration markers):

[Overlay.jl demo result](https://cursor.com/agents/bc-5e323e78-82c6-46ca-811b-28ed0d7343ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_demo_result.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e323e78-82c6-46ca-811b-28ed0d7343ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e323e78-82c6-46ca-811b-28ed0d7343ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

